### PR TITLE
Support giving a p-value threshold

### DIFF
--- a/check_graphite.gemspec
+++ b/check_graphite.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   # specify any dependencies here; for example:
   # s.add_development_dependency "rspec"
   s.add_runtime_dependency "linear-regression", "~> 0.0.2"
-  s.add_runtime_dependency "nagios_check"
+  s.add_runtime_dependency "nagios_check", "~> 0.4.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"

--- a/lib/check_graphite/projection.rb
+++ b/lib/check_graphite/projection.rb
@@ -10,6 +10,16 @@ module CheckGraphite
         options.send(:processor=, method(:projected_value))
         options.send(:timeframe=, timeframe)
       end
+
+      base.on '--p-threshold VALUE' do |raw_threshold|
+        begin
+          threshold = Float(raw_threshold)
+          raise "Expected 0 <= #{threshold} <= 1" unless threshold >= 0 && threshold <= 1
+          options.send(:p_threshold=, threshold)
+        rescue ArgumentError
+          raise "Expected #{raw_threshold} to be a float"
+        end
+      end
     end
 
     def projected_value(datapoints)
@@ -17,23 +27,32 @@ module CheckGraphite
       lr = Regression::Linear.new(xs, ys)
       future = CheckGraphite.attime(options.timeframe, xs[-1])
       value = lr.predict(future.to_i)
-      p = Regression::CorrelationCoefficient.new(xs, ys).pearson
-      store_value options.name, value
+      p = Regression::CorrelationCoefficient.new(xs, ys).pearson.abs
+      if is_good_p?(p)
+        store_value options.name, value
+        store_message "#{options.name}=#{format_float(value)} in #{options.timeframe}"
+      else
+        store_value options.name, nil
+        store_message "No projection on #{options.name}; p = #{format_float(p)} < #{options.p_threshold}"
+      end
       # Unfortunately, nagios_check converts both primary and
       # secondary values to float. Hence manual assignment instead:
-      @values['p-value'] = format_float(p.abs)
-      store_message "#{options.name}=#{format_float(value)} in #{options.timeframe}"
+      @values['p-value'] = format_float(p)
       return value
     end
 
     private
 
-     def format_float(v)
-       if v.nan?
-         'undefined'
-       else
-         BigDecimal.new(v, 3).to_s('F')
-       end
-     end
+    def is_good_p?(p)
+      options.p_threshold.nil? || p.nan? || p >= options.p_threshold
+    end
+
+    def format_float(v)
+      if v.nan?
+        'undefined'
+      else
+        BigDecimal.new(v, 3).to_s('F')
+      end
+    end
   end
 end

--- a/spec/projection_spec.rb
+++ b/spec/projection_spec.rb
@@ -108,9 +108,9 @@ describe 'when invoking graphite with --projection' do
   context 'given no --p-threshold' do
     let(:options) { ['--projection', '5min'] }
 
-    it 'outputs value, projection interval and p-value' do
+    it 'outputs value formatted to 3 significant digits, projection interval and p-value' do
       c = CheckGraphite::Command.new
-      STDOUT.should_receive(:puts).with(match(/ze-name.*in 5min.*p-value=0.9/))
+      STDOUT.should_receive(:puts).with(match(/ze-name=18.8 in 5min.*p-value=0.9/))
       lambda { c.run }.should raise_error SystemExit
     end
   end
@@ -118,9 +118,9 @@ describe 'when invoking graphite with --projection' do
   context 'given a low p-threshold' do
     let(:options) { ['--projection', '5min', '--p-threshold', '0.3'] }
 
-    it 'outputs value, projection interval and p-value' do
+    it 'outputs value formatted to 3 significant digits, projection interval and p-value' do
       c = CheckGraphite::Command.new
-      STDOUT.should_receive(:puts).with(match(/ze-name.*in 5min.*p-value=0.9/))
+      STDOUT.should_receive(:puts).with(match(/ze-name=18.8 in 5min.*p-value=0.9/))
       lambda { c.run }.should raise_error SystemExit
     end
   end
@@ -130,7 +130,7 @@ describe 'when invoking graphite with --projection' do
 
     it 'gives unknown status and says p-value is too low' do
       c = CheckGraphite::Command.new
-      STDOUT.should_receive(:puts).with(match(/UNKNOWN.*ze-name.*.*0.981 < 0.99/))
+      STDOUT.should_receive(:puts).with(match(/UNKNOWN: No projection on ze-name.*.*0.981 < 0.99/))
       lambda { c.run }.should raise_error SystemExit
     end
   end

--- a/spec/projection_spec.rb
+++ b/spec/projection_spec.rb
@@ -10,16 +10,30 @@ describe CheckGraphite::Projection do
     end.new
   end
 
+  describe 'when parsing a pearson threshold option' do
+    subject do |example|
+      check.prepare
+      check.send(:parse_options, example.metadata[:description_args][0])
+      check.options.p_threshold
+    end
+
+    it ['--p-threshold', '0.75'] { should eq(0.75) }
+    it ['--p-threshold', '2'] { expect { subject }.to raise_error(/0 <=.*2.*<= 1/) }
+    it ['--p-threshold', 'foo'] { expect { subject }.to raise_error(/float/) }
+  end
+
   describe 'when looking at the primary value' do
+    let(:projection) { '2sec' }
+    let(:options) { ['--projection', projection] }
+
     subject do
       check.prepare
-      check.send(:parse_options, ['--projection', projection])
+      check.send(:parse_options, options)
       check.options.processor.call(datapoints)
       check.values.first[1]
     end
 
     context 'given a linearly decreasing series and a projection of 2 sec' do
-      let(:projection) { '2sec' }
       let(:datapoints) { [[10,0], [9,1], [8,2]] }
 
       it 'linerarly extrapolates value to be 6' do
@@ -28,16 +42,34 @@ describe CheckGraphite::Projection do
     end
 
     context 'given a constant series and a projection of 2 sec' do
-      let(:projection) { '2sec' }
       let(:datapoints) { [[10,0], [10,1], [10,2]] }
 
       it 'linearly extrapolates the value to remain 01' do
         should be_within(0.01).of(10)
       end
     end
+
+    context 'given a constant series with a p-value below threshold' do
+      let(:datapoints) { [[10,0], [10,1], [10,2]] }
+      let(:options) { ['--projection', projection, '--p-threshold', '0.3'] }
+
+      it 'returns a projection even tho p-value is NaN' do
+        should be_within(0.01).of(10)
+      end
+    end
+
+    context 'given a series with a p-value below threshold' do
+      let(:datapoints) { [[5,0], [1,1], [10,2]] }
+      let(:options) { ['--projection', projection, '--p-threshold', '0.9'] }
+
+      it 'returns nil because nagios_check will turn it into UNKNOWN' do
+        should be(nil)
+      end
+    end
   end
 
   describe 'when looking at the p-value' do
+    let(:projection) { '2sec' }
     subject do
       check.prepare
       check.send(:parse_options, ['--projection', projection])
@@ -46,13 +78,11 @@ describe CheckGraphite::Projection do
     end
 
     context 'given a constant series (where Pearson is undefined)' do
-      let(:projection) { '2sec' }
       let(:datapoints) { [[10,0], [10,1], [10,2]] }
       it { should eq('undefined') }
     end
 
     context 'given a linearly decreasing series' do
-      let(:projection) { '2sec' }
       let(:datapoints) { [[10,0], [9,1], [8,2]] }
 
       it { should eq("1.0") }
@@ -67,18 +97,41 @@ describe 'when invoking graphite with --projection' do
       :body => '[{"target": "collectd.somebox.load.load.midterm", "datapoints": [[1.0, 1339512060], [2.0, 1339512120], [6.0, 1339512180], [7.0, 1339512240]]}]',
       :content_type => "application/json"
     )
-  end
-
-  it 'outputs value, projection interval and p-value' do
     stub_const("ARGV", %w{
       -H http://your.graphite.host/render
       -M collectd.somebox.load.load.midterm
       -c 0:10
-      --projection 5min
       --name ze-name
-    })
-    c = CheckGraphite::Command.new
-    STDOUT.should_receive(:puts).with(match(/ze-name.*in 5min.*p-value=0.9/))
-    lambda { c.run }.should raise_error SystemExit
+    } + options)
+  end
+
+  context 'given no --p-threshold' do
+    let(:options) { ['--projection', '5min'] }
+
+    it 'outputs value, projection interval and p-value' do
+      c = CheckGraphite::Command.new
+      STDOUT.should_receive(:puts).with(match(/ze-name.*in 5min.*p-value=0.9/))
+      lambda { c.run }.should raise_error SystemExit
+    end
+  end
+
+  context 'given a low p-threshold' do
+    let(:options) { ['--projection', '5min', '--p-threshold', '0.3'] }
+
+    it 'outputs value, projection interval and p-value' do
+      c = CheckGraphite::Command.new
+      STDOUT.should_receive(:puts).with(match(/ze-name.*in 5min.*p-value=0.9/))
+      lambda { c.run }.should raise_error SystemExit
+    end
+  end
+
+  context 'given a high p-threshold' do
+    let(:options) { ['--projection', '5min', '--p-threshold', '0.99'] }
+
+    it 'gives unknown status and says p-value is too low' do
+      c = CheckGraphite::Command.new
+      STDOUT.should_receive(:puts).with(match(/UNKNOWN.*ze-name.*.*0.981 < 0.99/))
+      lambda { c.run }.should raise_error SystemExit
+    end
   end
 end


### PR DESCRIPTION
When data is noisy, it makes sense to not trigger critical status, but neither is it necessarily a good thing. If ops thinks that checking against projected values, presumably the data is expected to be stable. This PR adds support for giving a threshold for a p-value calculated from the series retrieved from Graphite. If the p-value is above the threshold, behave as per normal. If the p-value is below threshold, this is probably not OK, so we raise unknown. This depends on upstream https://github.com/dbroeglin/nagios_check/pull/5 which was released as nagios_check 0.4.0.