### PR TITLE
Support giving a p-value threshold (merging again)

### DIFF
--- a/check_graphite.gemspec
+++ b/check_graphite.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   # specify any dependencies here; for example:
   # s.add_development_dependency "rspec"
   s.add_runtime_dependency "linear-regression", "~> 0.0.2"
-  s.add_runtime_dependency "nagios_check"
+  s.add_runtime_dependency "nagios_check", "~> 0.4.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"

--- a/lib/check_graphite/projection.rb
+++ b/lib/check_graphite/projection.rb
@@ -10,6 +10,16 @@ module CheckGraphite
         options.send(:processor=, method(:projected_value))
         options.send(:timeframe=, timeframe)
       end
+
+      base.on '--p-threshold VALUE' do |raw_threshold|
+        begin
+          threshold = Float(raw_threshold)
+          raise "Expected 0 <= #{threshold} <= 1" unless threshold >= 0 && threshold <= 1
+          options.send(:p_threshold=, threshold)
+        rescue ArgumentError
+          raise "Expected #{raw_threshold} to be a float"
+        end
+      end
     end
 
     def projected_value(datapoints)
@@ -17,23 +27,32 @@ module CheckGraphite
       lr = Regression::Linear.new(xs, ys)
       future = CheckGraphite.attime(options.timeframe, xs[-1])
       value = lr.predict(future.to_i)
-      p = Regression::CorrelationCoefficient.new(xs, ys).pearson
-      store_value options.name, value
+      p = Regression::CorrelationCoefficient.new(xs, ys).pearson.abs
+      if is_good_p?(p)
+        store_value options.name, value
+        store_message "#{options.name}=#{format_float(value)} in #{options.timeframe}"
+      else
+        store_value options.name, nil
+        store_message "No projection on #{options.name}; p = #{format_float(p)} < #{options.p_threshold}"
+      end
       # Unfortunately, nagios_check converts both primary and
       # secondary values to float. Hence manual assignment instead:
-      @values['p-value'] = format_float(p.abs)
-      store_message "#{options.name}=#{format_float(value)} in #{options.timeframe}"
+      @values['p-value'] = format_float(p)
       return value
     end
 
     private
 
-     def format_float(v)
-       if v.nan?
-         'undefined'
-       else
-         BigDecimal.new(v, 3).to_s('F')
-       end
-     end
+    def is_good_p?(p)
+      options.p_threshold.nil? || p.nan? || p >= options.p_threshold
+    end
+
+    def format_float(v)
+      if v.nan?
+        'undefined'
+      else
+        BigDecimal.new(v, 3).to_s('F')
+      end
+    end
   end
 end

--- a/lib/check_graphite/projection.rb
+++ b/lib/check_graphite/projection.rb
@@ -5,6 +5,14 @@ require 'linear-regression'
 
 module CheckGraphite
   module Projection
+    def self.to_s_signif_digits(v)
+      if v.nan?
+        'undefined'
+      else
+        BigDecimal.new(v.to_s).add(0, 3).to_s('F')
+      end
+    end
+
     def self.included(base)
       base.on '--projection FUTURE_TIMEFRAME', :default => '2days' do |timeframe|
         options.send(:processor=, method(:projected_value))
@@ -30,14 +38,14 @@ module CheckGraphite
       p = Regression::CorrelationCoefficient.new(xs, ys).pearson.abs
       if is_good_p?(p)
         store_value options.name, value
-        store_message "#{options.name}=#{format_float(value)} in #{options.timeframe}"
+        store_message "#{options.name}=#{Projection.to_s_signif_digits(value)} in #{options.timeframe}"
       else
         store_value options.name, nil
-        store_message "No projection on #{options.name}; p = #{format_float(p)} < #{options.p_threshold}"
+        store_message "No projection on #{options.name}; p = #{Projection.to_s_signif_digits(p)} < #{options.p_threshold}"
       end
       # Unfortunately, nagios_check converts both primary and
       # secondary values to float. Hence manual assignment instead:
-      @values['p-value'] = format_float(p)
+      @values['p-value'] = Projection.to_s_signif_digits(p)
       return value
     end
 
@@ -45,14 +53,6 @@ module CheckGraphite
 
     def is_good_p?(p)
       options.p_threshold.nil? || p.nan? || p >= options.p_threshold
-    end
-
-    def format_float(v)
-      if v.nan?
-        'undefined'
-      else
-        BigDecimal.new(v, 3).to_s('F')
-      end
     end
   end
 end

--- a/spec/projection_spec.rb
+++ b/spec/projection_spec.rb
@@ -108,9 +108,9 @@ describe 'when invoking graphite with --projection' do
   context 'given no --p-threshold' do
     let(:options) { ['--projection', '5min'] }
 
-    it 'outputs value, projection interval and p-value' do
+    it 'outputs value formatted to 3 significant digits, projection interval and p-value' do
       c = CheckGraphite::Command.new
-      STDOUT.should_receive(:puts).with(match(/ze-name.*in 5min.*p-value=0.9/))
+      STDOUT.should_receive(:puts).with(match(/ze-name=18.8 in 5min.*p-value=0.9/))
       lambda { c.run }.should raise_error SystemExit
     end
   end
@@ -118,9 +118,9 @@ describe 'when invoking graphite with --projection' do
   context 'given a low p-threshold' do
     let(:options) { ['--projection', '5min', '--p-threshold', '0.3'] }
 
-    it 'outputs value, projection interval and p-value' do
+    it 'outputs value formatted to 3 significant digits, projection interval and p-value' do
       c = CheckGraphite::Command.new
-      STDOUT.should_receive(:puts).with(match(/ze-name.*in 5min.*p-value=0.9/))
+      STDOUT.should_receive(:puts).with(match(/ze-name=18.8 in 5min.*p-value=0.9/))
       lambda { c.run }.should raise_error SystemExit
     end
   end
@@ -130,7 +130,7 @@ describe 'when invoking graphite with --projection' do
 
     it 'gives unknown status and says p-value is too low' do
       c = CheckGraphite::Command.new
-      STDOUT.should_receive(:puts).with(match(/UNKNOWN.*ze-name.*.*0.981 < 0.99/))
+      STDOUT.should_receive(:puts).with(match(/UNKNOWN: No projection on ze-name.*.*0.981 < 0.99/))
       lambda { c.run }.should raise_error SystemExit
     end
   end

--- a/spec/projection_spec.rb
+++ b/spec/projection_spec.rb
@@ -10,16 +10,30 @@ describe CheckGraphite::Projection do
     end.new
   end
 
+  describe 'when parsing a pearson threshold option' do
+    subject do |example|
+      check.prepare
+      check.send(:parse_options, example.metadata[:description_args][0])
+      check.options.p_threshold
+    end
+
+    it ['--p-threshold', '0.75'] { should eq(0.75) }
+    it ['--p-threshold', '2'] { expect { subject }.to raise_error(/0 <=.*2.*<= 1/) }
+    it ['--p-threshold', 'foo'] { expect { subject }.to raise_error(/float/) }
+  end
+
   describe 'when looking at the primary value' do
+    let(:projection) { '2sec' }
+    let(:options) { ['--projection', projection] }
+
     subject do
       check.prepare
-      check.send(:parse_options, ['--projection', projection])
+      check.send(:parse_options, options)
       check.options.processor.call(datapoints)
       check.values.first[1]
     end
 
     context 'given a linearly decreasing series and a projection of 2 sec' do
-      let(:projection) { '2sec' }
       let(:datapoints) { [[10,0], [9,1], [8,2]] }
 
       it 'linerarly extrapolates value to be 6' do
@@ -28,16 +42,34 @@ describe CheckGraphite::Projection do
     end
 
     context 'given a constant series and a projection of 2 sec' do
-      let(:projection) { '2sec' }
       let(:datapoints) { [[10,0], [10,1], [10,2]] }
 
       it 'linearly extrapolates the value to remain 01' do
         should be_within(0.01).of(10)
       end
     end
+
+    context 'given a constant series with a p-value below threshold' do
+      let(:datapoints) { [[10,0], [10,1], [10,2]] }
+      let(:options) { ['--projection', projection, '--p-threshold', '0.3'] }
+
+      it 'returns a projection even tho p-value is NaN' do
+        should be_within(0.01).of(10)
+      end
+    end
+
+    context 'given a series with a p-value below threshold' do
+      let(:datapoints) { [[5,0], [1,1], [10,2]] }
+      let(:options) { ['--projection', projection, '--p-threshold', '0.9'] }
+
+      it 'returns nil because nagios_check will turn it into UNKNOWN' do
+        should be(nil)
+      end
+    end
   end
 
   describe 'when looking at the p-value' do
+    let(:projection) { '2sec' }
     subject do
       check.prepare
       check.send(:parse_options, ['--projection', projection])
@@ -46,13 +78,11 @@ describe CheckGraphite::Projection do
     end
 
     context 'given a constant series (where Pearson is undefined)' do
-      let(:projection) { '2sec' }
       let(:datapoints) { [[10,0], [10,1], [10,2]] }
       it { should eq('undefined') }
     end
 
     context 'given a linearly decreasing series' do
-      let(:projection) { '2sec' }
       let(:datapoints) { [[10,0], [9,1], [8,2]] }
 
       it { should eq("1.0") }
@@ -67,18 +97,41 @@ describe 'when invoking graphite with --projection' do
       :body => '[{"target": "collectd.somebox.load.load.midterm", "datapoints": [[1.0, 1339512060], [2.0, 1339512120], [6.0, 1339512180], [7.0, 1339512240]]}]',
       :content_type => "application/json"
     )
-  end
-
-  it 'outputs value, projection interval and p-value' do
     stub_const("ARGV", %w{
       -H http://your.graphite.host/render
       -M collectd.somebox.load.load.midterm
       -c 0:10
-      --projection 5min
       --name ze-name
-    })
-    c = CheckGraphite::Command.new
-    STDOUT.should_receive(:puts).with(match(/ze-name.*in 5min.*p-value=0.9/))
-    lambda { c.run }.should raise_error SystemExit
+    } + options)
+  end
+
+  context 'given no --p-threshold' do
+    let(:options) { ['--projection', '5min'] }
+
+    it 'outputs value, projection interval and p-value' do
+      c = CheckGraphite::Command.new
+      STDOUT.should_receive(:puts).with(match(/ze-name.*in 5min.*p-value=0.9/))
+      lambda { c.run }.should raise_error SystemExit
+    end
+  end
+
+  context 'given a low p-threshold' do
+    let(:options) { ['--projection', '5min', '--p-threshold', '0.3'] }
+
+    it 'outputs value, projection interval and p-value' do
+      c = CheckGraphite::Command.new
+      STDOUT.should_receive(:puts).with(match(/ze-name.*in 5min.*p-value=0.9/))
+      lambda { c.run }.should raise_error SystemExit
+    end
+  end
+
+  context 'given a high p-threshold' do
+    let(:options) { ['--projection', '5min', '--p-threshold', '0.99'] }
+
+    it 'gives unknown status and says p-value is too low' do
+      c = CheckGraphite::Command.new
+      STDOUT.should_receive(:puts).with(match(/UNKNOWN.*ze-name.*.*0.981 < 0.99/))
+      lambda { c.run }.should raise_error SystemExit
+    end
   end
 end

--- a/spec/projection_spec.rb
+++ b/spec/projection_spec.rb
@@ -1,6 +1,27 @@
 require 'check_graphite/projection'
 require 'nagios_check'
 
+describe 'CheckGraphite::Projection.to_s_signif_digits' do
+  it 'nan is expressed as "undefined"' do
+    expect(CheckGraphite::Projection.to_s_signif_digits(Float::NAN)).to eq('undefined')
+  end
+  it 'formats small floats with 3 significant digits' do
+    expect(CheckGraphite::Projection.to_s_signif_digits(1.2345677)).to eq('1.23')
+  end
+  it 'formats small floats with 3 significant digits, rounding 0.5 up' do
+    expect(CheckGraphite::Projection.to_s_signif_digits(1.235)).to eq('1.24')
+  end
+  it 'formats large floats with 3 significant digits' do
+    expect(CheckGraphite::Projection.to_s_signif_digits(1334999.0)).to eq('1330000.0')
+  end
+  it 'formats 1.0 as 1.0 to show it is a float despite trailing zero not being significant' do
+    expect(CheckGraphite::Projection.to_s_signif_digits(1.0)).to eq('1.0')
+  end
+  it 'formats really small float as decimal, defeating rubys urge to print anything smaller than 1e-4 in engineering notation' do
+    expect(CheckGraphite::Projection.to_s_signif_digits(0.000002345678)).to eq('0.00000235')
+  end
+end
+
 describe CheckGraphite::Projection do
   let :check do
     Class.new do


### PR DESCRIPTION
Support alerting against a linear projection into the future of the time series retrieved from Graphite. E.g. --projection 30min means that a future value will be calculated using linear regression and that value will be offered to nagios_check for evaluation against warning/critical thresholds. The check also presents the p-value of that projection so that ops people has a chance of judging whether the alarm is the result of noisy data.

Using a simple projection is superior in some use cases where the rate of change is relatively stable, because it saves us from having to estimate the rate of change. Instead we can just say e.g.: "Give me 6 hours advance notice on the disk filling up."

This branch was mistakenly merged against linear-regression branch -- after it had been merged to master. Merging p-value-threshold again against master.