### PR TITLE
Document --p-threshold, and raise relevant error when passed without --projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ check_graphite accepts the following options:
 * `-t`: timeout after which the metric should be considered unknown
 * `--ignore-missing`: return `OK` when the metric doesn't exist yet e.g. errors have not occurred
 * `--projection`: Warn on a value linearly extrapolated into the future, defaults to "2days"
+* `--p-threshold`: Return unknown unless p-value exceeds the given value 0-1
 
 ## How it works
 

--- a/lib/check_graphite/projection.rb
+++ b/lib/check_graphite/projection.rb
@@ -31,6 +31,8 @@ module CheckGraphite
     end
 
     def projected_value(datapoints)
+      validate_options
+
       ys, xs = datapoints.transpose
       lr = Regression::Linear.new(xs, ys)
       future = CheckGraphite.attime(options.timeframe, xs[-1])
@@ -50,6 +52,12 @@ module CheckGraphite
     end
 
     private
+
+    def validate_options
+      if options.processor.nil? && !options.p_threshold.nil?
+        raise '--p-threshold without --projection'
+      end
+    end
 
     def is_good_p?(p)
       options.p_threshold.nil? || p.nan? || p >= options.p_threshold

--- a/spec/projection_spec.rb
+++ b/spec/projection_spec.rb
@@ -41,6 +41,16 @@ describe CheckGraphite::Projection do
     it ['--p-threshold', '0.75'] { should eq(0.75) }
     it ['--p-threshold', '2'] { expect { subject }.to raise_error(/0 <=.*2.*<= 1/) }
     it ['--p-threshold', 'foo'] { expect { subject }.to raise_error(/float/) }
+
+    describe 'when passing --p-threshold without' do
+      it 'should fail with error saying you need to give --projection' do
+        expect {
+          check.prepare
+          check.send(:parse_options, ['--p-threshold', '0.75'])
+          check.projected_value([[10,0], [9,1], [8,2]])
+        }.to raise_error(/--projection/)
+      end
+    end
   end
 
   describe 'when looking at the primary value' do


### PR DESCRIPTION
Improve on #4. Reusing branch p-value-threshold to make future upstream merge simpler.