### PR TITLE
Option --to look at older data

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ check_graphite accepts the following options:
 * `-H` or `--endpoint`: the graphite HTTP endpoint which can be queried
 * `-M` or `--metric`: the metric expression which will be queried, it can be an expression
 * `-F` or `--from`: time frame for which to query metrics, defaults to "30seconds"
+* `--to`: will exclude the time frame's worth of recent data
 * `--minimum`: require a minimum interval for returned data; if actual datapoints don't span interval, do UNKNOWN
 * `-N` or `--name`: name to give to the metric, defaults to "value"
 * `-U` or `--username`: username used for basic authentication

--- a/lib/check_graphite.rb
+++ b/lib/check_graphite.rb
@@ -14,6 +14,7 @@ module CheckGraphite
     on "--endpoint ENDPOINT", "-H ENDPOINT", :mandatory
     on "--metric METRIC", "-M METRIC", :mandatory
     on "--from TIMEFRAME", "-F TIMEFRAME", :default => "30seconds"
+    on "--to TIMEFRAME", :default => nil
     on "--minimum TIMEFRAME", :default => nil
     on "--name NAME", "-N NAME", :default => :value
     on "--username USERNAME", "-U USERNAME"
@@ -29,7 +30,9 @@ module CheckGraphite
     enable_timeout
 
     def check
-      uri = URI(URI.encode("#{options.endpoint}?target=#{options.metric}&from=-#{options.from}&format=json"))
+      prefix = "#{options.endpoint}?target=#{options.metric}&from=-#{options.from}"
+      prefix += "&until=-#{options.to}" if options.to
+      uri = URI(URI.encode("#{prefix}&format=json"))
       req = Net::HTTP::Get.new(uri.request_uri)
 
       # use basic auth if username is set


### PR DESCRIPTION
Adds `--to TIMEFRAME` on the same format as `--from` to select an endpoint other than "now" for your check. Supports at least two relevant use cases:
- It lets you see what the result would have been for old data. You may have a data-series for some time that you want to add a check for or perhaps you check against a calculated metric. You can use `--to` by hand to see what the result would have been for some past window
- It lets you ignore the most recent measurement. Perhaps you have systems that report infrequently or with a delay; with `--to` you can give them a grace period.