### PR TITLE
Minimum time interval option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ check_graphite accepts the following options:
 * `-H` or `--endpoint`: the graphite HTTP endpoint which can be queried
 * `-M` or `--metric`: the metric expression which will be queried, it can be an expression
 * `-F` or `--from`: time frame for which to query metrics, defaults to "30seconds"
+* `--minimum`: require a minimum interval for returned data; if actual datapoints don't span interval, do UNKNOWN
 * `-N` or `--name`: name to give to the metric, defaults to "value"
 * `-U` or `--username`: username used for basic authentication
 * `-P` or `--password`: password used for basic authentication

--- a/spec/check_graphite_spec.rb
+++ b/spec/check_graphite_spec.rb
@@ -45,6 +45,20 @@ describe CheckGraphite::Command do
       lambda { c.run }.should raise_error SystemExit
     end
 
+    it "should return UNKNOWN when data does not span minimum interval" do
+      stub_const("ARGV", %w{ -H http://your.graphite.host/render -M collectd.somebox.load.load.midterm -c 0 --minimum 200sec })
+      c = CheckGraphite::Command.new
+      STDOUT.should_receive(:puts).with(/UNKNOWN: Not enough valid datapoints/)
+      lambda { c.run }.should raise_error SystemExit
+    end
+
+    it "should operate normally when returned data matches minimum interval" do
+      stub_const("ARGV", %w{ -H http://your.graphite.host/render -M collectd.somebox.load.load.midterm -c 0 --minimum 170sec })
+      c = CheckGraphite::Command.new
+      STDOUT.should_receive(:puts).with("CRITICAL: value=4.0|value=4.0;;;;")
+      lambda { c.run }.should raise_error SystemExit
+    end
+
     it "should honour dropfirst" do
       stub_const("ARGV", %w{ -H http://your.graphite.host/render -M collectd.somebox.load.load.midterm --dropfirst 1 })
       c = CheckGraphite::Command.new
@@ -114,7 +128,7 @@ describe CheckGraphite::Command do
     it "should be unknown" do
       stub_const("ARGV", %w{ -H http://your.graphite.host/render -M all.values.null })
       c = CheckGraphite::Command.new
-      STDOUT.should_receive(:puts).with(/UNKNOWN: INTERNAL ERROR: (RuntimeError: )?no valid datapoints/)
+      STDOUT.should_receive(:puts).with(/UNKNOWN: Not enough valid datapoints/)
       lambda { c.run }.should raise_error SystemExit
     end
   end


### PR DESCRIPTION
Introduce a `--minimum TIMEFRAME` that yields UNKNOWN unless the returned datapoints spans at least `TIMEFRAME` interval. In particular, this is useful for letting metrics stabilize before sounding the alarm, e.g. if you scale in a new node in a cluster. Timeframe is on the same format as `--from`, e.g. `--minimum 2hours`.